### PR TITLE
(exchange-sdk) refactor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2774,11 +2774,11 @@
       }
     },
     "fetch-this": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-this/-/fetch-this-0.2.0.tgz",
-      "integrity": "sha512-vWZlM6DhKnmJVWtT/oNdPL+AxARJp4K5XPW5rJGUTeqIaISZIobSI9FHg4rwMjAfbqMvbX1BqI4qzeWVQEQZUA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/fetch-this/-/fetch-this-0.3.0.tgz",
+      "integrity": "sha512-5n4tFFCONKrVOPLziFRQbYjHT8KvxqCqn4BAoSU3dkiLvBVVUm02id2dE0gJSo4Cw7rjE934IWUmLPRXUU+SsA==",
       "requires": {
-        "handlebars": "4.0.11"
+        "lodash.get": "4.4.2"
       }
     },
     "figures": {

--- a/package.json
+++ b/package.json
@@ -9,10 +9,9 @@
   },
   "dependencies": {
     "express": "^4.16.2",
-    "fetch-this": "^0.2.0",
+    "fetch-this": "^0.3.0",
     "handlebars": "^4.0.11",
     "lodash.flow": "^3.5.0",
-    "lodash.get": "^4.4.2",
     "lodash.reverse": "^4.0.1",
     "lodash.sortby": "^4.7.0"
   },

--- a/src/app/dashboard.test.js
+++ b/src/app/dashboard.test.js
@@ -4,6 +4,7 @@ import {
   loadFakeReturns,
   resetFakeReturns,
 } from '../exchange-sdk/fake-sdk'
+
 describe('#getDashboard', () => {
   const sdk = { getPrice }
 
@@ -26,6 +27,10 @@ describe('#getDashboard', () => {
       },
     ],
   }
+
+  afterAll(() => {
+    resetFakeReturns()
+  })
 
   test('should return a dashboard, sorted by max profit', async () => {
     loadFakeReturns({

--- a/src/exchange-sdk/fake-sdk.js
+++ b/src/exchange-sdk/fake-sdk.js
@@ -1,7 +1,11 @@
-let urlAndResultsCache
+let urlAndResultsCache = {}
 
 export const loadFakeReturns = (urlAndResults) => {
   urlAndResultsCache = urlAndResults
+}
+
+export const resetFakeReturns = () => {
+  urlAndResultsCache = {}
 }
 
 export const getPrice = async (exchange, payload) => {

--- a/src/exchange-sdk/sdk.js
+++ b/src/exchange-sdk/sdk.js
@@ -1,6 +1,5 @@
-import fetchThis from 'fetch-this'
+import { fetchThis, getResult } from 'fetch-this'
 import Handlebars from 'handlebars'
-import get from 'lodash.get'
 
 Handlebars.registerHelper('upper', (str) => {
   if (!str || typeof str !== 'string') {
@@ -10,14 +9,20 @@ Handlebars.registerHelper('upper', (str) => {
 })
 
 export const getPrice = async (exchange, payload) => {
-  const response = await fetchThis(exchange.api.fetch, payload)
-  const body = await response.json()
-
-  if (!exchange.api.result) {
-    return body
+  const compile = (template) => {
+    if (!template) return ''
+    return Handlebars.compile(template)(payload)
   }
 
-  const resultPath = Handlebars.compile(exchange.api.result)(payload)
+  const data = {
+    fetch: {
+      url: compile(exchange.api.fetch.url),
+    },
+    result: compile(exchange.api.result),
+  }
 
-  return get(body, resultPath)
+  const response = await fetchThis(data)
+  const value = await getResult(response, data)
+
+  return value
 }

--- a/src/exchange-sdk/sdk.js
+++ b/src/exchange-sdk/sdk.js
@@ -1,5 +1,6 @@
 import { fetchThis, getResult } from 'fetch-this'
 import Handlebars from 'handlebars'
+import flow from 'lodash.flow'
 
 Handlebars.registerHelper('upper', (str) => {
   if (!str || typeof str !== 'string') {
@@ -8,18 +9,19 @@ Handlebars.registerHelper('upper', (str) => {
   return str.toUpperCase()
 })
 
-export const getPrice = async (exchange, payload) => {
-  const compile = (template) => {
-    if (!template) return ''
-    return Handlebars.compile(template)(payload)
-  }
+// TODO: move this logic to a new package
+// perf note: "stringify/compile/parse" performs better than "recursive compile"
+//  the last one performs worse as object gets larger or deeper
+const compileObj = (obj, payload) => (
+  flow([
+    JSON.stringify,
+    (_) => Handlebars.compile(_)(payload),
+    JSON.parse,
+  ])(obj)
+)
 
-  const data = {
-    fetch: {
-      url: compile(exchange.api.fetch.url),
-    },
-    result: compile(exchange.api.result),
-  }
+export const getPrice = async (exchange, payload) => {
+  const data = compileObj(exchange.api, payload)
 
   const response = await fetchThis(data)
   const value = await getResult(response, data)


### PR DESCRIPTION
use new fetch-this version
this new version does not compile templates for us anymore
it's intentional: the idea here is to move object template expansion to another abstraction
for now, I'm just creating a function that compiles an object for expanded version

---

I'm not using recursion on object expansion. I'm using stringify instead.
Here's a microbenchmark between the two approachs:
![image](https://user-images.githubusercontent.com/413430/35716637-53756d94-07c1-11e8-8db1-9f8de287c3ba.png)

This micro benchmark uses an object that is big for our use case (but not that big), the performance difference is 20%. And the difference will grow for larger/deeper objects.

But testing with a simpler object, very possible on our application, the difference is still 10%.

I think the performance drop on the "deep" case is due to `JavaScript` not supporting [tail recursion](https://stackoverflow.com/questions/33923/what-is-tail-recursion). So, recursions can drop performance drops easily as sample increases, leading to a heap out of memory if not taken seriously.
