### PR TITLE
move background jobs simulation to inside dashboard

### DIFF
--- a/src/app/dashboard.js
+++ b/src/app/dashboard.js
@@ -1,11 +1,15 @@
 import flow from 'lodash.flow'
 import reverse from 'lodash.reverse'
 import sortBy from 'lodash.sortby'
+import * as bookService from '../exchange/services/populate-book-cache'
 import * as profitService from '../exchange/services/populate-profit-cache'
 import * as bookCache from '../exchange/data-access/book-dao'
 import * as profitCache from '../exchange/data-access/profit-dao'
 
 export const getDashboard = async ({ userAmount, currency }) => {
+  // TODO: move this logic to a background job
+  await simulateBackgroundJobAlreadyRunned()
+
   // TODO: create a currency cache
   const amount = (await simulateGetCurrencyFromCache(currency)) * userAmount
 
@@ -43,4 +47,21 @@ const buildDashboard = (profits) => (
 const simulateGetCurrencyFromCache = async (currency) => {
   const response = await fetch('http://free.currencyconverterapi.com/api/v3/convert?q=BRL_USD&compact=y')
   return (await response.json()).BRL_USD.val
+}
+
+const simulateBackgroundJobAlreadyRunned = async () => {
+  // invalidate caches, populate book cache, prepopulate profit cache
+
+  // invalidate caches
+  await Promise.all([
+    bookCache.invalidate(),
+    profitCache.invalidate(),
+  ])
+
+  // prepopulate book cache
+  await bookService.populateCache()
+
+  // TODO: on a real background job
+  //  prepopulate profit cache with some predefined amounts
+  // ex.: await profitService.populateProfitCache({ ..., amount: predefinedAmount  })
 }

--- a/src/index-express.js
+++ b/src/index-express.js
@@ -1,16 +1,10 @@
 import express from 'express'
 import { getDashboard } from './app/dashboard'
-import * as bookCache from './exchange/data-access/book-dao'
-import * as profitCache from './exchange/data-access/profit-dao'
-import * as bookService from './exchange/services/populate-book-cache'
 
 const server = express()
 const port = 3001
 
 server.get('/dashboard', async (req, res) => {
-  // TODO: move this logic to a background job
-  await simulateBackgroundJobAlreadyRunned()
-
   try {
     const userAmount = req.query.amount
     const currency = req.query.currency
@@ -22,23 +16,6 @@ server.get('/dashboard', async (req, res) => {
     res.status(500).end()
   }
 })
-
-const simulateBackgroundJobAlreadyRunned = async () => {
-  // invalidate caches, populate book cache, prepopulate profit cache
-
-  // invalidate caches
-  await Promise.all([
-    bookCache.invalidate(),
-    profitCache.invalidate(),
-  ])
-
-  // prepopulate book cache
-  await bookService.populateCache()
-
-  // TODO: on a real background job
-  //  prepopulate profit cache with some predefined amounts
-  // ex.: await profitService.populateProfitCache({ ..., amount: predefinedAmount  })
-}
 
 server.listen(port, () => {
   console.log(`Server listening on port ${port}!`) // eslint-disable-line


### PR DESCRIPTION
A small refactor this time, just just moving the background job simulation to inside app/dashboard.

A simulation doesn't belong anywhere, it's just a temporary workaround until the proper background jobs take place.
Why not inside index-express then?
Because index-express is just the express framework entry point, we shouldn't complicate it with simulation  stuff. If app/dashboard needs background jobs working, let it simulate it then.

I came to this conclusion while working on the `feat/deploy` branch. I created another entry point `index-lambda` to be the entry point for AWS lambda, and replicating the simulation there doesn't seems to be ok.