### PR TITLE
Feat/lambda http

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,58 @@
 # crypto-api
 API for cryptocurrency arbitrage app
+
+## How to deploy
+
+### Create a IAM on an AWS account
+- Give it permissions:
+  - all permissions, // TODO enumerate only needed permissions
+- Store the credential as `CryptoArb` profile on AWS credentials file (probably on path `~/.aws/credentials`)
+```
+[CryptoArb]
+aws_access_key_id = XXXXXXXXXXXXXXXXXXXX
+aws_secret_access_key = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+```
+
+### Use Serverless Framework (sls) to deploy to AWS
+- Deploy to AWS (it will use `CriptoArb` profile)
+```
+npx sls deploy
+```
+
+- Wait until the command finishes.
+- In case of succes, it will output a message similar to:
+```
+Serverless: Stack update finished...
+Service Information
+service: crypto-api
+stage: dev
+region: us-east-2
+stack: crypto-api-dev
+api keys:
+  None
+endpoints:
+  GET - https://xxxxxxxxxx.execute-api.us-east-2.amazonaws.com/dev/dashboard
+functions:
+  dashboard: crypto-api-dev-dashboard
+```
+
+### Show deployed resources ID's
+- Use the info command while verbose to print stack outputs
+```
+npx sls info --verbose
+```
+- It will print something with a `Stack Outputs` section similar to:
+```
+Stack Outputs
+UserPoolClientId: xxxxxxxxxxxxxxxxxxxxxxxxxx
+UserPoolId: us-east-2_XXXXXXXXX
+IdentityPoolId: us-east-2:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+ServiceEndpoint: https://xxxxxxxxxx.execute-api.us-east-2.amazonaws.com/dev
+```
+
+
+### Create a test user
+- Use scripts/create_test_user.sh passing email and password
+```
+./scripts/create_test_user.sh change-me@email.com change-to-a-strong-password
+```

--- a/config/serverless/cognito-identity-pool.yml
+++ b/config/serverless/cognito-identity-pool.yml
@@ -1,0 +1,78 @@
+Resources:
+  # The federated identity for our user pool to auth with
+  CognitoIdentityPool:
+    Type: AWS::Cognito::IdentityPool
+    Properties:
+      # Generate a name based on the stage
+      IdentityPoolName: ${self:custom.stage}IdentityPool
+      # Don't allow unathenticated users
+      AllowUnauthenticatedIdentities: false
+      # Link to our User Pool
+      CognitoIdentityProviders:
+        - ClientId:
+            Ref: CognitoUserPoolClient
+          ProviderName:
+            Fn::GetAtt: [ "CognitoUserPool", "ProviderName" ]
+
+  # IAM roles
+  CognitoIdentityPoolRoles:
+    Type: AWS::Cognito::IdentityPoolRoleAttachment
+    Properties:
+      IdentityPoolId:
+        Ref: CognitoIdentityPool
+      Roles:
+        authenticated:
+          Fn::GetAtt: [CognitoAuthRole, Arn]
+
+  # IAM role used for authenticated users
+  CognitoAuthRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Path: /
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: 'Allow'
+            Principal:
+              Federated: 'cognito-identity.amazonaws.com'
+            Action:
+              - 'sts:AssumeRoleWithWebIdentity'
+            Condition:
+              StringEquals:
+                'cognito-identity.amazonaws.com:aud':
+                  Ref: CognitoIdentityPool
+              'ForAnyValue:StringLike':
+                'cognito-identity.amazonaws.com:amr': authenticated
+      Policies:
+        - PolicyName: 'CognitoAuthorizedPolicy'
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: 'Allow'
+                Action:
+                  - 'mobileanalytics:PutEvents'
+                  - 'cognito-sync:*'
+                  - 'cognito-identity:*'
+                Resource: '*'
+
+              # Allow users to invoke our API
+              - Effect: 'Allow'
+                Action:
+                  - 'execute-api:Invoke'
+                Resource:
+                  Fn::Join:
+                    - ''
+                    -
+                      - 'arn:aws:execute-api:'
+                      - Ref: AWS::Region
+                      - ':'
+                      - Ref: AWS::AccountId
+                      - ':'
+                      - Ref: ApiGatewayRestApi
+                      - '/*'
+
+# Print out the Id of the Identity Pool that is created
+Outputs:
+  IdentityPoolId:
+    Value:
+      Ref: CognitoIdentityPool

--- a/config/serverless/cognito-user-pool.yml
+++ b/config/serverless/cognito-user-pool.yml
@@ -1,0 +1,32 @@
+Resources:
+  CognitoUserPool:
+    Type: AWS::Cognito::UserPool
+    Properties:
+      # Generate a name based on the stage
+      UserPoolName: ${self:custom.stage}-user-pool
+      # Set email as an alias
+      UsernameAttributes:
+        - email
+      AutoVerifiedAttributes:
+        - email
+
+  CognitoUserPoolClient:
+    Type: AWS::Cognito::UserPoolClient
+    Properties:
+      # Generate an app client name based on the stage
+      ClientName: ${self:custom.stage}-user-pool-client
+      UserPoolId:
+        Ref: CognitoUserPool
+      ExplicitAuthFlows:
+        - ADMIN_NO_SRP_AUTH
+      GenerateSecret: false
+
+# Print out the Id of the User Pool that is created
+Outputs:
+  UserPoolId:
+    Value:
+      Ref: CognitoUserPool
+
+  UserPoolClientId:
+    Value:
+      Ref: CognitoUserPoolClient

--- a/package-lock.json
+++ b/package-lock.json
@@ -405,6 +405,27 @@
         "to-fast-properties": "2.0.0"
       }
     },
+    "@puresec/function-shield": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@puresec/function-shield/-/function-shield-1.2.0.tgz",
+      "integrity": "sha512-oacITH2Lv9816WyErhts1NDXecmqvpUmpTfm/B4s8L5IU9c8Ojj5bzVTQDhg4XdzJphxVZEj5MOQAwWaRlG8AA==",
+      "requires": {
+        "fs-extra": "7.0.1",
+        "node-gyp-build": "3.5.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "jsonfile": "4.0.0",
+            "universalify": "0.1.2"
+          }
+        }
+      }
+    },
     "@serverless/platform-sdk": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@serverless/platform-sdk/-/platform-sdk-0.2.0.tgz",
@@ -470,6 +491,16 @@
           }
         }
       }
+    },
+    "@types/aws-lambda": {
+      "version": "8.10.15",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.15.tgz",
+      "integrity": "sha512-C8yoqVslZ0CxQBTsBIBzAlG+JfevToteoJxzqvYSWGUcnw3oBu05Pe2P/I4hg3udR9qpsCJowXA65L9NYnJbrA=="
+    },
+    "@types/http-errors": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.6.1.tgz",
+      "integrity": "sha512-s+RHKSGc3r0m3YEE2UXomJYrpQaY9cDmNDLU2XvG1/LAZsQ7y8emYkTLfcw/ByDtcsTyRQKwr76Bj4PkN2hfWg=="
     },
     "@webassemblyjs/ast": {
       "version": "1.5.13",
@@ -784,6 +815,11 @@
         "json-schema-traverse": "0.4.1",
         "uri-js": "4.2.2"
       }
+    },
+    "ajv-i18n": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/ajv-i18n/-/ajv-i18n-3.3.0.tgz",
+      "integrity": "sha512-6X/yd/Ept9HSJoCr9mFpKQ3WG7w7ou+4p/t8REos1xL0qRDwrlFJa3LxyeOlQxu7FdyLdu0ss4204pUa3SkgQQ=="
     },
     "ajv-keywords": {
       "version": "3.2.0",
@@ -6807,6 +6843,11 @@
       "integrity": "sha512-FD/SedD78LCdSvJaOUQAXseT8oQBb5z6IVYaQaCrVUlu9zOAr1BDdKyVYQaSD/GDsAMrXpKcOyBD4LIl8nfjHw==",
       "dev": true
     },
+    "json-mask": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/json-mask/-/json-mask-0.3.8.tgz",
+      "integrity": "sha1-LWZBXeFLDovGwVFFVKkL/Kg1aUE="
+    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -7246,6 +7287,26 @@
         "to-regex": "3.0.2"
       }
     },
+    "middy": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/middy/-/middy-0.19.2.tgz",
+      "integrity": "sha512-9HAJaL7n4d4gnzi2CGCDvPJ1XjdKMcei8zlHoyFfvUImt5WGY3jD6PGiAAVmBoqq/Rbqr2XplkbmyGls9VX9Eg==",
+      "requires": {
+        "@puresec/function-shield": "1.2.0",
+        "@types/aws-lambda": "8.10.15",
+        "@types/http-errors": "1.6.1",
+        "ajv": "6.5.2",
+        "ajv-i18n": "3.3.0",
+        "ajv-keywords": "3.2.0",
+        "content-type": "1.0.4",
+        "http-errors": "1.6.3",
+        "json-mask": "0.3.8",
+        "negotiator": "0.6.1",
+        "once": "1.4.0",
+        "qs": "6.5.1",
+        "querystring": "0.2.0"
+      }
+    },
     "miller-rabin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
@@ -7466,6 +7527,11 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.0.tgz",
       "integrity": "sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA=="
+    },
+    "node-gyp-build": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.5.0.tgz",
+      "integrity": "sha512-qjEE8eIWVyqZhkAFUzytGpOGvLHeX5kXBB6MYyTOCPZBrBlsLyXAAzTsp/hWMbVlg8kVpzDJCZZowIrnKpwmqQ=="
     },
     "node-int64": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lodash.keyby": "^4.6.0",
     "lodash.reverse": "^4.0.1",
     "lodash.sortby": "^4.7.0",
+    "middy": "^0.19.2",
     "node-fetch": "^2.2.0",
     "regenerator-runtime": "^0.12.0",
     "serverless-webpack": "^5.2.0",

--- a/scripts/create_test_user.sh
+++ b/scripts/create_test_user.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+PROJECT_PROFILE="CryptoArb"
+
+die() {
+  echo -e >&2 "\nError: $@\n"
+  exit 1
+}
+
+# verify args
+if [ $# -ne 2 ]; then
+  die "usage: $0 <email> <passsword>"
+fi
+
+# aws cli should be installed
+(
+  command -v aws &>/dev/null
+)
+if [ $? -ne 0 ]; then
+  die "awscli should be installed"
+fi
+
+# aws profile should exist
+(
+  aws configure --profile $PROJECT_PROFILE list &>/dev/null
+)
+if [ $? -ne 0 ]; then
+  die "AWS profile $PROJECT_PROFILE should exist"
+fi
+
+# aws cli should be working with profile
+(
+  export AWS_PROFILE=$PROJECT_PROFILE
+  aws s3 ls &>/dev/null
+)
+if [ $? -ne 0 ]; then
+  die "awscli unexpected error"
+fi
+
+# change dir to project root
+cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null
+cd ..
+
+# test user from args
+TEST_USER_EMAIL=$1
+TEST_USER_PASSWORD=$2
+
+# collect project data
+SLS_OUTPUT=$(npx sls info --verbose)
+REGION=$(echo "$SLS_OUTPUT" | grep 'region: ' | cut -d' ' -f2)
+USER_POOL_CLIENT_ID=$(echo "$SLS_OUTPUT" | grep 'UserPoolClientId: ' | cut -d' ' -f2)
+USER_POOL_ID=$(echo "$SLS_OUTPUT" | grep 'UserPoolId: ' | cut -d' ' -f2)
+
+# create user
+(
+  aws cognito-idp sign-up \
+   --region $REGION \
+   --client-id $USER_POOL_CLIENT_ID \
+   --username $TEST_USER_EMAIL \
+   --password $TEST_USER_PASSWORD
+)
+if [ $? -ne 0 ]; then
+  die "fail to sign-up user"
+fi
+
+# confirm user
+(
+  export AWS_PROFILE=$PROJECT_PROFILE
+  AWS_PROFILE=$PROJECT_PROFILE aws cognito-idp admin-confirm-sign-up \
+    --region $REGION \
+    --user-pool-id $USER_POOL_ID \
+    --username $TEST_USER_EMAIL
+)
+if [ $? -ne 0 ]; then
+  die "fail confirm user sign-up"
+fi

--- a/serverless.yml
+++ b/serverless.yml
@@ -30,6 +30,7 @@ functions:
       - http:
           path: dashboard
           method: get
+          authorizer: aws_iam
 
 resources:
   # Cognito

--- a/serverless.yml
+++ b/serverless.yml
@@ -31,6 +31,11 @@ functions:
           path: dashboard
           method: get
           authorizer: aws_iam
+          request:
+            parameters:
+              querystrings:
+                amount: true
+                currency: false
 
 resources:
   # Cognito

--- a/serverless.yml
+++ b/serverless.yml
@@ -17,7 +17,7 @@ provider:
     project: CryptoArb
   runtime: nodejs8.10
   stage: dev
-  region: sa-east-1
+  region: us-east-2
   profile: CryptoArb
   memorySize: 128
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -32,6 +32,8 @@ functions:
           path: dashboard
           method: get
           authorizer: aws_iam
+          cors:
+            origin: 'http://localhost:3000'
           request:
             parameters:
               querystrings:

--- a/serverless.yml
+++ b/serverless.yml
@@ -18,6 +18,7 @@ provider:
   runtime: nodejs8.10
   stage: dev
   region: us-east-2
+  endpointType: regional
   profile: CryptoArb
   memorySize: 128
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -4,6 +4,8 @@ plugins:
   - serverless-webpack
 
 custom:
+  # Use stage option from cli, fallbacks to provider section
+  stage: ${opt:stage, self:provider.stage}
   # serverless-webpack configuration
   webpack:
     webpackConfig: ./config/webpack/webpack.config.js
@@ -28,3 +30,7 @@ functions:
       - http:
           path: dashboard
           method: get
+
+resources:
+  # Cognito
+  - ${file(config/serverless/cognito-user-pool.yml)}

--- a/serverless.yml
+++ b/serverless.yml
@@ -23,3 +23,7 @@ functions:
     handler: src/index-lambda.dashboard
     memorySize: 128
     timeout: 5
+    events:
+      - http:
+          path: dashboard
+          method: get

--- a/serverless.yml
+++ b/serverless.yml
@@ -34,3 +34,4 @@ functions:
 resources:
   # Cognito
   - ${file(config/serverless/cognito-user-pool.yml)}
+  - ${file(config/serverless/cognito-identity-pool.yml)}

--- a/serverless.yml
+++ b/serverless.yml
@@ -24,7 +24,7 @@ provider:
 
 functions:
   dashboard:
-    handler: src/index-lambda.dashboard
+    handler: src/lambda/dashboard.default
     memorySize: 128
     timeout: 5
     events:

--- a/serverless.yml
+++ b/serverless.yml
@@ -16,6 +16,7 @@ provider:
   runtime: nodejs8.10
   stage: dev
   region: sa-east-1
+  profile: CryptoArb
   memorySize: 128
 
 functions:

--- a/src/index-lambda.js
+++ b/src/index-lambda.js
@@ -2,9 +2,11 @@
 import 'regenerator-runtime/runtime'
 global.fetch = require('node-fetch')
 
+import middy from 'middy'
+import { cors } from 'middy/middlewares'
 import { getDashboard } from './app/dashboard'
 
-export const dashboard = async (event, context, callback) => {
+const dashboardHandler = async (event, context, callback) => {
   const userAmount = event.queryStringParameters.amount
   const currency = event.queryStringParameters.currency
 
@@ -17,3 +19,6 @@ export const dashboard = async (event, context, callback) => {
 
   callback(null, response)
 }
+
+export const dashboard = middy(dashboardHandler)
+  .use(cors())

--- a/src/index-lambda.js
+++ b/src/index-lambda.js
@@ -18,10 +18,7 @@ export const dashboard = async (event, context, callback) => {
 
   const response = {
     statusCode: 200,
-    body: JSON.stringify({
-      message: dashboard,
-      input: event,
-    }),
+    body: JSON.stringify(dashboard),
   }
 
   callback(null, response)

--- a/src/index-lambda.js
+++ b/src/index-lambda.js
@@ -4,12 +4,6 @@ global.fetch = require('node-fetch')
 
 import { getDashboard } from './app/dashboard'
 
-/*
- * npx sls invoke local \
- *  -f dashboard \
- *  -d '{"queryStringParameters": {"amount":"1000", "currency": "brl"}}'
- */
-
 export const dashboard = async (event, context, callback) => {
   const userAmount = event.queryStringParameters.amount
   const currency = event.queryStringParameters.currency

--- a/src/lambda/dashboard.js
+++ b/src/lambda/dashboard.js
@@ -4,9 +4,9 @@ global.fetch = require('node-fetch')
 
 import middy from 'middy'
 import { cors } from 'middy/middlewares'
-import { getDashboard } from './app/dashboard'
+import { getDashboard } from '../app/dashboard'
 
-const dashboardHandler = async (event, context, callback) => {
+const dashboard = async (event, context, callback) => {
   const userAmount = event.queryStringParameters.amount
   const currency = event.queryStringParameters.currency
 
@@ -20,5 +20,5 @@ const dashboardHandler = async (event, context, callback) => {
   callback(null, response)
 }
 
-export const dashboard = middy(dashboardHandler)
+export default middy(dashboard)
   .use(cors())


### PR DESCRIPTION
This PR does a few things related to aws lambda:
- make dashboard lambda accessble via http on api gateway
- adds cognito auth to dashboard api
- adds CORS to api (until we figure out another way to prevent CORS issue on dev environment)
- move lambda to US because there is no Cognito em Sao Paulo
- adds a script to help create cognito user for testing purpuses
- add deployment docs

Docs is something that we usually don't improve and it's merged, so please make sure it's helpful by following those steps.

---

This task started on Jun 13 and then was put on hold to work on the serverless setup and other stuff.
I got back to it on Aug 2, but we got stucked on a bug related to create-react-app proxy and cognito validations.
But it's finaly here! :tada: 