### PR TITLE
remove fetch this

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4138,14 +4138,6 @@
         "pend": "1.2.0"
       }
     },
-    "fetch-this": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/fetch-this/-/fetch-this-0.4.0.tgz",
-      "integrity": "sha512-KCcwoPkpHPKWwwbEaq6dfPZ/8wdZQQIrHve1/21hs4bbrXJxdNIBoyvTzHmF0wQ2K8XnTUbb+p0d9lxCWYSaZA==",
-      "requires": {
-        "lodash.get": "4.4.2"
-      }
-    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8537,11 +8537,6 @@
       "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
       "dev": true
     },
-    "regenerator-runtime": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.0.tgz",
-      "integrity": "sha512-SpV2LhF5Dm9UYMEprB3WwsBnWwqTrmjrm2UZb42cl2G02WVGgx7Mg8aa9pdLEKp6hZ+/abcMc2NxKA8f02EG2w=="
-    },
     "regenerator-transform": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "babel-runtime": "^6.26.0",
     "expand-json": "^0.3.0",
     "express": "^4.16.3",
-    "fetch-this": "^0.4.0",
     "generatorics": "^1.1.0",
     "lodash.flow": "^3.5.0",
     "lodash.get": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "lodash.sortby": "^4.7.0",
     "middy": "^0.19.2",
     "node-fetch": "^2.2.0",
-    "regenerator-runtime": "^0.12.0",
     "serverless-webpack": "^5.2.0",
     "source-map-support": "^0.5.6",
     "webpack": "^4.16.3",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "fetch-this": "^0.4.0",
     "generatorics": "^1.1.0",
     "lodash.flow": "^3.5.0",
+    "lodash.get": "^4.4.2",
     "lodash.keyby": "^4.6.0",
     "lodash.reverse": "^4.0.1",
     "lodash.sortby": "^4.7.0",

--- a/src/exchange/vendor-api/fetch-util.js
+++ b/src/exchange/vendor-api/fetch-util.js
@@ -1,8 +1,18 @@
-import { fetchThis, getResult } from 'fetch-this'
+import get from 'lodash.get'
 
 export const fetchByConfig = async (config) => {
-  const response = await fetchThis(config.fetch)
+  const response = await fetch(config.fetch.url)
   const value = await getResult(response, config.result)
 
   return value
+}
+
+const getResult = async (response, resultConfig) => {
+  const json = await response.json()
+
+  if (!resultConfig) {
+    return json
+  }
+
+  return get(json, resultConfig)
 }

--- a/src/index-development.js
+++ b/src/index-development.js
@@ -1,5 +1,4 @@
 require('babel-register')
-require('regenerator-runtime/runtime')
 
 global.fetch = require('node-fetch')
 

--- a/src/lambda/dashboard.js
+++ b/src/lambda/dashboard.js
@@ -1,5 +1,4 @@
 // environment bootstrap
-import 'regenerator-runtime/runtime'
 global.fetch = require('node-fetch')
 
 import middy from 'middy'


### PR DESCRIPTION
By using fetchThis forces us to also install and use regenerator-runtime, that helps us use `await` on environments that doesn't support it. But turns out that our node version do support `await`, so regenerator-runtime is adding complexity to deploy bundle and slowing down code for nothing.
The easiest way to get rid of this regenerator-runtime is by just removing fetchThis.

The package fetchThis in the other hand is doing a lot less than was planned in the beggining, so let's just remove it for the sake of simplicity.
